### PR TITLE
fixup for .env.default

### DIFF
--- a/backend/.env.default
+++ b/backend/.env.default
@@ -1,12 +1,12 @@
-DATABASE_URL="postgresql://postgres@postgres:5432/<development | test>?schema=public&connection_limit=1"
-FRONTEND_URL="http://localhost:3000"
-SWAGGER_TITLE="title"
-SWAGGER_DESCRIPTION="description"
-SWAGGER_VERSION="0.0.0"
-JWT_SECRET_KEY="secret"
+DATABASE_URL=postgresql://postgres@postgres:5432/<development | test>
+FRONTEND_URL=http://localhost:3000
+SWAGGER_TITLE=title
+SWAGGER_DESCRIPTION=description
+SWAGGER_VERSION=0.0.0
+JWT_SECRET_KEY=secret
 JWT_ACCESS_TOKEN_EXPIRE_TIME=300
 JWT_REFRESH_TOKEN_EXPIRE_TIME=300
-HTTP_COOKIE_REFRESH_TOKEN_NAME="refreshToken"
+HTTP_COOKIE_REFRESH_TOKEN_NAME=refreshToken
 HTTP_COOKIE_EXPIRE_TIME=99999
 HTTP_COOKIE_DOMAIN=test
 HTTP_COOKIE_SAME_SITE=strict


### PR DESCRIPTION
- The DATABASE_URL was not valid and prisma errored on it.
- quotes are not neccessary and lessens syntax highlighting in env
  (shell) files.
